### PR TITLE
fix data transmission error on the netlify API endpoint

### DIFF
--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -45,7 +45,7 @@ export async function handler(event,context) {
     console.log("POST request received");
 
     const body = JSON.parse(event.body);
-    const uid = body.uid;
+    const uid = body.username;
     const hashpass = body.hashpass;
 
     console.log("Request body:", body);


### PR DESCRIPTION
refactored uid to get body.username instead of body.uid, since body.uid doesn't exist in the login form.