### PR TITLE
remove !email from params check.

### DIFF
--- a/src/workers/d1-api.js
+++ b/src/workers/d1-api.js
@@ -304,7 +304,7 @@ export default {
             const lname = url.searchParams.get("lname");
             const dob = url.searchParams.get("dob");
             const doj = url.searchParams.get("doj");
-            if(!uid || !email || !fname || !lname || !dob || !doj) {
+            if(!uid || !fname || !lname || !dob || !doj) {
                 return addCorsHeaders(new Response(JSON.stringify({ error: "bad params" }), { status: 400 }));
             }
 


### PR DESCRIPTION
this was causing the info not to reach the database even though email was deprecated in that table